### PR TITLE
Config - Allowed Host Filter for aws deploy

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,9 @@
 # https://www.playframework.com/documentation/latest/Configuration
+play.filters.enabled += play.filters.hosts.AllowedHostsFilter
+play.filters.hosts {
+  # Allow requests to example.com, its subdomains, and localhost:9000.
+  allowed = [".amazonaws.com/", "localhost:9000"]
+}
 
 # Configuracion basica de conexión a la base de datos MySQL
 db {


### PR DESCRIPTION
Configuración para que el servidor backend permita consultas de localhost como prueba y aws.