### PR TITLE
Config - Allowed Host Filter for aws deploy- alternative trying using .

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,8 +1,8 @@
 # https://www.playframework.com/documentation/latest/Configuration
-play.filters.enabled += play.filters.hosts.AllowedHostsFilter
+# play.filters.enabled += play.filters.hosts.AllowedHostsFilter
 play.filters.hosts {
   # Allow requests to example.com, its subdomains, and localhost:9000.
-  allowed = ["*.amazonaws.com/", "localhost:9000"]
+  allowed = ["."]
 }
 
 # Configuracion basica de conexión a la base de datos MySQL


### PR DESCRIPTION
La alternativa de * no es aceptada por el .conf de scala, para esto existe una alternativa de usar .